### PR TITLE
feat: Handle ydb specific queries by queries-ydb.properties file

### DIFF
--- a/keycloak-ydb-extension/core/src/main/kotlin/tech/ydb/keycloak/connection/YdbConnectionProviderFactoryImpl.kt
+++ b/keycloak-ydb-extension/core/src/main/kotlin/tech/ydb/keycloak/connection/YdbConnectionProviderFactoryImpl.kt
@@ -197,8 +197,19 @@ class YdbConnectionProviderFactoryImpl : JpaConnectionProviderFactory, ServerInf
       val properties = buildPropertiesFromScope()
 
       entityManagerFactory = JpaUtils.createEntityManagerFactory(session, PERSISTENCE_UNIT_NAME, properties, jtaEnabled)
+      addSpecificNamedQueries()
       logger.info("YDB EntityManagerFactory created via JpaUtils")
       return entityManagerFactory
+    }
+  }
+
+  /**
+   * Load YDB-specific named query overrides from META-INF/queries-ydb.properties.
+   * Follows the same pattern as DefaultJpaConnectionProviderFactory.addSpecificNamedQueries().
+   */
+  private fun addSpecificNamedQueries() = entityManagerFactory.createEntityManager().use { em ->
+    JpaUtils.loadSpecificNamedQueries(DB_KIND).forEach { (queryName, querySql) ->
+      JpaUtils.configureNamedQuery(queryName.toString(), querySql.toString(), em)
     }
   }
 
@@ -309,5 +320,6 @@ class YdbConnectionProviderFactoryImpl : JpaConnectionProviderFactory, ServerInf
     }
 
     const val PERSISTENCE_UNIT_NAME = "keycloak-default"
+    const val DB_KIND = "ydb"
   }
 }

--- a/keycloak-ydb-extension/core/src/main/resources/META-INF/queries-ydb.properties
+++ b/keycloak-ydb-extension/core/src/main/resources/META-INF/queries-ydb.properties
@@ -1,0 +1,31 @@
+# YDB-specific named query overrides.
+#
+# 1. YDB requires each JOIN ON predicate to reference columns from both sides of the join.
+#    These queries move filter conditions (column = :param) from ON to WHERE.
+# 2. YDB does not support implicit cross joins (comma-separated FROM).
+#    These queries replace "FROM A, B WHERE b = a.field" with explicit JOINs.
+
+findUserSessionsByClientId[jpql]=SELECT sess FROM PersistentUserSessionEntity sess \
+ INNER JOIN PersistentClientSessionEntity clientSess \
+ ON sess.userSessionId = clientSess.userSessionId AND sess.offline = clientSess.offline \
+ WHERE clientSess.clientId = :clientId \
+ AND sess.offline = :offline \
+ AND sess.realmId = :realmId \
+ AND sess.lastSessionRefresh >= :lastSessionRefresh \
+ ORDER BY sess.userSessionId
+
+findUserSessionsByExternalClientId[jpql]=SELECT sess FROM PersistentUserSessionEntity sess \
+ INNER JOIN PersistentClientSessionEntity clientSess \
+ ON sess.userSessionId = clientSess.userSessionId AND sess.offline = clientSess.offline \
+ WHERE clientSess.clientStorageProvider = :clientStorageProvider \
+ AND clientSess.externalClientId = :externalClientId \
+ AND sess.offline = :offline \
+ AND sess.realmId = :realmId \
+ AND sess.lastSessionRefresh >= :lastSessionRefresh \
+ ORDER BY sess.userSessionId
+
+# Original: select u from UserRoleMappingEntity m, UserEntity u where m.roleId=:roleId and u=m.user order by u.username
+# YDB does not support implicit cross join (comma-separated FROM).
+usersInRole[jpql]=SELECT m.user FROM UserRoleMappingEntity m \
+ WHERE m.roleId = :roleId \
+ ORDER BY m.user.username


### PR DESCRIPTION
Some queries are not supported in YDB.
That's why keycloak already has util functions where we can change implementation of named query.

So I implemented it in this PR

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Ydb does not support some queries and keycloak with ydb does not work

Issue Number: N/A

## What is the new behavior?

Created `queries-ydb.properties` file where will be listed all changes of named queries. Used keycloak util functions `configureNamedQuery` and `loadSpecificNamedQueries` to implement it


## Other information

As example you can see `addSpecificNamedQueries` function here

https://github.com/keycloak/keycloak/blob/main/model/jpa/src/main/java/org/keycloak/connections/jpa/DefaultJpaConnectionProviderFactory.java
